### PR TITLE
Upgraded version installed.

### DIFF
--- a/git-lfs-install/git-lfs.install.nuspec
+++ b/git-lfs-install/git-lfs.install.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>git-lfs.install</id>
     <title>Git Large File Storage (Install)</title>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <authors>GitHub Inc</authors>
     <owners>IOZ AG</owners>
     <projectUrl>https://git-lfs.github.com/</projectUrl>

--- a/git-lfs-install/tools/ChocolateyInstall.ps1
+++ b/git-lfs-install/tools/ChocolateyInstall.ps1
@@ -1,7 +1,7 @@
 $packageName = 'git-lfs'
 $installerType = 'exe'
-$silentArgs = "/S"
-$32BitUrl  = 'https://github.com/github/git-lfs/releases/download/v1.1.0/git-lfs-windows-amd64-1.1.0.exe'
+$silentArgs = "/VERYSILENT"
+$32BitUrl  = 'https://github.com/github/git-lfs/releases/download/v1.1.1/git-lfs-windows-1.1.1.exe'
 $validExitCodes = @(
     0 # success
 )

--- a/git-lfs-install/tools/ChocolateyInstall.ps1
+++ b/git-lfs-install/tools/ChocolateyInstall.ps1
@@ -1,6 +1,6 @@
 $packageName = 'git-lfs'
 $installerType = 'exe'
-$silentArgs = "/VERYSILENT"
+$silentArgs = "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
 $32BitUrl  = 'https://github.com/github/git-lfs/releases/download/v1.1.1/git-lfs-windows-1.1.1.exe'
 $validExitCodes = @(
     0 # success

--- a/git-lfs/git-lfs.nuspec
+++ b/git-lfs/git-lfs.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>git-lfs</id>
     <title>Git Large File Storage</title>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <authors>GitHub Inc</authors>
     <owners>IOZ AG</owners>
     <projectUrl>https://git-lfs.github.com/</projectUrl>


### PR DESCRIPTION
As per iozag#8, a new version of
git-lfs has been released. This installer uses innosetup so requires a new
flag to be a silent install. Also included in this pull request is the updated
installer.