### PR TITLE
Adding "vscode" to tags for better searchabaility

### DIFF
--- a/visualstudiocode/VisualStudioCode.nuspec
+++ b/visualstudiocode/VisualStudioCode.nuspec
@@ -33,7 +33,7 @@ The following package parameters can be set:
 These parameters can be passed to the installer with the use of `-params`.
 For example: `-params '"/nodesktopicon /dontaddtopath"'`.
     </description>
-    <tags>Microsoft Visual Studio Code editor ide admin</tags>
+    <tags>Microsoft VisualStudioCode vscode editor ide admin</tags>
     <releaseNotes>
         https://code.visualstudio.com/Updates
         Added command line arguments. Context menu and desktop icon will be created after the installation.

--- a/visualstudiocode/VisualStudioCode.nuspec
+++ b/visualstudiocode/VisualStudioCode.nuspec
@@ -33,7 +33,7 @@ The following package parameters can be set:
 These parameters can be passed to the installer with the use of `-params`.
 For example: `-params '"/nodesktopicon /dontaddtopath"'`.
     </description>
-    <tags>Microsoft VisualStudioCode vscode editor ide admin</tags>
+    <tags>Microsoft VisualStudioCode vscode editor ide javascript typescript admin</tags>
     <releaseNotes>
         https://code.visualstudio.com/Updates
         Added command line arguments. Context menu and desktop icon will be created after the installation.


### PR DESCRIPTION
Also condensing "Visual Studio Code" into one word, since Chocolatey doesn't seem to support spaces in tag names.